### PR TITLE
Update to node-sodium@1.1.12

### DIFF
--- a/install.js
+++ b/install.js
@@ -348,7 +348,7 @@ if (os.platform() !== 'win32') {
         });
     } else {
         console.log('Install Mode');
-        run('node-gyp rebuild', function() {
+        run('node-gyp rebuild', 0, function() {
             console.log('Copy lib files to Release folder');
             files = libFiles.slice(0); // clone array
             copyFiles(files, function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sodium",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "author": "Pedro Paixao <paixaop@gmail.com>",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "sodium",
+  "name": "sodium-prebuilt",
   "version": "1.1.12",
   "author": "Pedro Paixao <paixaop@gmail.com>",
   "license": "MIT",
-  "main": "index.js",
-  "description": "Lib Sodium port for node.js",
+  "description": "Prebuilds for Lib Sodium port for node.js",
   "dependencies": {
-    "nan": "^2.2.1"
+    "nan": "^2.2.1",
+    "prebuild": "^4.1.0"
   },
   "devDependencies": {
     "mdextract": "^1.0.0",
@@ -17,12 +17,12 @@
   },
   "scripts": {
     "test": "make test",
-    "preinstall": "node install.js --preinstall",
-    "install": "node install.js --install"
+    "install": "prebuild --install --no-compile || node install.js --preinstall && node install.js --install",
+    "prebuild": "node install.js --preinstall && prebuild --all --verbose"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/paixaop/node-sodium"
+    "url": "https://github.com/mafintosh/node-sodium-prebuilt"
   },
   "keywords": [
     "encryption",


### PR DESCRIPTION
Upstream has advanced quite a bit (`1.0.22 -> 1.1.12`) - dunno how useful this PR is, but I figured _some_ kind of PR is better than showing up empty handed on Twitter. The whole thing is just 9e0d720 on top of the upstream tag `1.1.12`.

Main issue was dealing with the changes to the `preinstall` and `install` targets in upstream's `package.json`. Since prebuild's `--preinstall` option doesn't support arguments, I used `&&` and `||` which seems to work, but... not convinced this won't break in some situations.

Successfully tested `npm run prebuild` on Linux x64 and Win32 x64.
