### PR TITLE
manually move dll for windows

### DIFF
--- a/copy_dll
+++ b/copy_dll
@@ -1,0 +1,8 @@
+#! /usr/bin/sh
+
+if [ -f deps/build/lib/libsodium.dll ];
+then
+  echo 'copying libsodium.dll into Releases'
+  cp deps/build/lib/libsodium.dll build/Releases/
+fi
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sodium-prebuilt",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "author": "Pedro Paixao <paixaop@gmail.com>",
   "license": "MIT",
   "main": "index.js",
@@ -19,6 +19,7 @@
   "scripts": {
     "test": "make test",
     "install": "prebuild --install --preinstall \"node install.js --preinstall && node install.js --install\"",
+    "postinstall": "./copy_dll",
     "prebuild": "prebuild --all --preinstall \"node install.js --preinstall && node install.js --install\""
   },
   "repository": {


### PR DESCRIPTION
I've been trying to get sodium-prebuilt to build on windows.

My solution is not elegant - the code written should work, but I've been seeing a strange bug where [copyFile](https://github.com/mafintosh/node-sodium-prebuilt/blob/master/install.js#L182-L204) is really not copying the files.
Hopefully the reason is something obvious

My setup : node 6.8.1, Cygwin on windows 10

I'm going to publish a clearer version of these [notes](https://gist.github.com/mixmix/7cfad548b1358ad7b38f1e937895afd8) about how I set up my build env
