### PR TITLE
upgrade prebuild{,-{ci,install}}

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,18 +7,21 @@
   "description": "Prebuilds for Lib Sodium port for node.js",
   "dependencies": {
     "nan": "^2.2.1",
-    "prebuild": "^4.3.0"
+    "prebuild": "^4.3.0",
+    "prebuild-install": "^2.1.0"
   },
   "devDependencies": {
-    "mdextract": "^1.0.0",
     "istanbul": ">=0.4.3",
+    "mdextract": "^1.0.0",
     "mocha": ">=2.4.5",
     "mocha-istanbul": ">=0.2.0",
-    "node-gyp": ">=3.3.1"
+    "node-gyp": ">=3.3.1",
+    "prebuild-ci": "^2.0.0",
+    "prebuild-install": "^2.1.0"
   },
   "scripts": {
     "test": "make test",
-    "install": "prebuild --install --preinstall \"node install.js --preinstall && node install.js --install\"",
+    "install": "node install.js --preinstall && node install.js --install && prebuild-install || node-gyp rebuild",
     "prebuild": "prebuild --all --preinstall \"node install.js --preinstall && node install.js --install\""
   },
   "repository": {


### PR DESCRIPTION
not sure if i refactored the --preinstall script correctly...

This gives us automated electron builds through prebuild-ci and a smaller dep tree through prebuild-install