### PR TITLE
Add support for more BSD systems

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -77,6 +77,11 @@
           '../deps/build/lib/libsodium.lib'
         ]
       }],
+      ['OS=="openbsd"', {
+        'libraries': [
+          '../deps/build/lib/libsodium.a'
+        ]
+      }],
       ['OS=="linux"', {
         'libraries': [
           '../deps/build/lib/libsodium.a'

--- a/binding.gyp
+++ b/binding.gyp
@@ -40,6 +40,9 @@
       'deps/build/include',
       "<!(node -e \"require('nan')\")"
     ],
+    'libraries': [
+      '../deps/build/lib/libsodium.a'
+    ],
     'cflags': ['-fPIC'],
     'configurations': {
       'Debug': {
@@ -59,9 +62,6 @@
     },
     'conditions': [
       ['OS=="mac"', {
-        'libraries': [
-          '../deps/build/lib/libsodium.a'
-        ],
         'variables': {
           'osx_min_version': "<!(sw_vers -productVersion | awk -F \'.\' \'{print $1 \".\" $2}\')"
         },
@@ -75,16 +75,6 @@
       ['OS=="win"', {
         'libraries': [
           '../deps/build/lib/libsodium.lib'
-        ]
-      }],
-      ['OS=="openbsd"', {
-        'libraries': [
-          '../deps/build/lib/libsodium.a'
-        ]
-      }],
-      ['OS=="linux"', {
-        'libraries': [
-          '../deps/build/lib/libsodium.a'
         ]
       }]
     ]

--- a/install.js
+++ b/install.js
@@ -329,11 +329,15 @@ function isPreInstallMode() {
 
 
 // Start
+var make = 'make';
+if (os.platform() === 'openbsd') {
+    make = "gmake"
+}
 if (os.platform() !== 'win32') {
     if (isPreInstallMode()) {
-        run('make libsodium');
+        run(make + ' libsodium');
     } else {
-        run('make nodesodium');
+        run(make + ' nodesodium');
     }
 } else {
     checkMSVSVersion();

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node-gyp": ">=3.3.1"
   },
   "scripts": {
-    "test": "make test",
+    "test": "./run_test.sh",
     "install": "prebuild --install --preinstall \"node install.js --preinstall && node install.js --install\"",
     "prebuild": "prebuild --all --preinstall \"node install.js --preinstall && node install.js --install\""
   },

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+OS=$(uname)
+
+case $OS in
+	OpenBSD)
+		gmake test
+		;;
+	FreeBSD)
+		gmake test
+		;;
+	*)
+		make test
+esac

--- a/test/test_aead_aes256gcm.js
+++ b/test/test_aead_aes256gcm.js
@@ -3092,7 +3092,6 @@ describe("AEAD", function() {
     // If CPU does not support AES256gcm don't test
     if (!sodium.crypto_aead_aes256gcm_is_available()) {
         console.log('AES 256 gcm not supported by CPU');
-        done();
         return;
     }
     it('aes256gcm should work for all ' + tests.length + ' test vectors', function(done) {


### PR DESCRIPTION
This allows sodium-prebuilt to function on systems like FreeBSD and OpenBSD.

I don't have a FreeBSD box - so testing is a bit sparse on that end (will likely need a similar gmake fix in install.js).